### PR TITLE
Update TBB URL and hash in CMake configuration

### DIFF
--- a/deps/TBB/TBB.cmake
+++ b/deps/TBB/TBB.cmake
@@ -1,7 +1,7 @@
 bambustudio_add_cmake_project(
     TBB
-    URL "https://github.com/wjakob/tbb/archive/a0dc9bf76d0120f917b641ed095360448cabc85b.tar.gz"
-    URL_HASH SHA256=0545cb6033bd1873fcae3ea304def720a380a88292726943ae3b9b207f322efe
+    URL "https://github.com/wjakob/tbb/archive/e07dd0fd6b215325d3b9fd272c6cdb6d2c55e093.zip"
+    URL_HASH SHA256=52b3d056fba461eb0c5a2b7442e2f30bb4b6a498ad4480654791e3bb2e6da194
     PATCH_COMMAND ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-TBB-GCC13.patch
     CMAKE_ARGS
         -DTBB_BUILD_SHARED=OFF


### PR DESCRIPTION
cmake: bump minimum required version to 3.10
Compilation fix for newer compiler versions